### PR TITLE
Make vizName in Format public.

### DIFF
--- a/graphviz-java/src/main/java/guru/nidi/graphviz/engine/Format.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/engine/Format.java
@@ -34,7 +34,7 @@ public enum Format {
     PS("ps", false, false),
     JSON("json", false, false);
 
-    final String vizName;
+    public final String vizName;
     final boolean image;
     final boolean svg;
 


### PR DESCRIPTION
I'd like to use the name for generating the proper file here - https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/51. However it's currently not public