### PR TITLE
mvn: batik, svg-salamander as provided dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,24 @@ BufferedImage image = viz.render(Format.PNG).toImage();
 <img src="https://rawgit.com/nidi3/graphviz-java/master/graphviz-java/example/ex5s.png" width="100">
 <img src="https://rawgit.com/nidi3/graphviz-java/master/graphviz-java/example/ex5.svg" width="100">
 
+For rasterize, provide the relevant libraries on the classpath:
+
+```xml
+<dependency>
+    <groupId>org.apache.xmlgraphics</groupId>
+    <artifactId>batik-rasterizer</artifactId>
+    <version>1.10</version>
+    <scope>runtime</scope>
+</dependency>
+<!-- or -->
+<dependency>
+    <groupId>com.kitfox.svg</groupId>
+    <artifactId>svg-salamander</artifactId>
+    <version>1.0</version>
+    <scope>runtime</scope>
+</dependency>
+```
+
 ### Font size
 The layout of a graph is done with Javascript / natively and the rendering with Java.
 The two environments are not guaranteed to calculate the width of text the same way.

--- a/graphviz-java/pom.xml
+++ b/graphviz-java/pom.xml
@@ -85,16 +85,19 @@
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-rasterizer</artifactId>
             <version>1.10</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-codec</artifactId>
             <version>1.10</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>xmlgraphics-commons</artifactId>
             <version>2.3</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -107,18 +110,12 @@
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
         </dependency>
-        <!--<dependency>-->
-        <!--<groupId>com.kitfox</groupId>-->
-        <!--<artifactId>svgSalamander</artifactId>-->
-        <!--<version>1.1.2</version>-->
-        <!--<scope>system</scope>-->
-        <!--<systemPath>${basedir}/src/main/resources/svgSalamander-1.1.2.jar</systemPath>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-        <!--<groupId>com.kitfox.svg</groupId>-->
-        <!--<artifactId>svg-salamander</artifactId>-->
-        <!--<version>1.0</version>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>com.kitfox.svg</groupId>
+            <artifactId>svg-salamander</artifactId>
+            <version>1.0</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>net.arnx</groupId>
             <artifactId>nashorn-promise</artifactId>


### PR DESCRIPTION
This avoids transitive inclusion of possibly not needed dependencies.