### PR TITLE
add method addLink() to be able to provide link attributes

### DIFF
--- a/graphviz-java/src/main/java/guru/nidi/graphviz/model/MutableNode.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/model/MutableNode.java
@@ -115,6 +115,11 @@ public class MutableNode implements MutableAttributed<MutableNode, ForNode>, Lin
         return this;
     }
 
+    public MutableNode addLink(Link link) {
+        links.add(link);
+        return this;
+    }
+
     @Override
     public LinkTarget asLinkTarget() {
         return this;


### PR DESCRIPTION
Adds a method `addLink(Link)` to `MutableNode` to allow to modify link attributes directly.

Solves #136 .

This seemed to be the easiest way to solve #136. Let me know if there is another way. Would be great to get this (or a similar solution) merged so I can use it in my project :).