### PR TITLE
Fallback classloader when there is no context classloader.

### DIFF
--- a/graphviz-java/src/main/java/guru/nidi/graphviz/engine/IoUtils.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/engine/IoUtils.java
@@ -33,7 +33,14 @@ final class IoUtils {
     }
 
     static boolean isOnClasspath(String resource) {
-        return Thread.currentThread().getContextClassLoader().getResource(resource) != null;
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = IoUtils.class.getClassLoader();
+        }
+        if (classLoader == null) {
+            classLoader = ClassLoader.getSystemClassLoader();
+        }
+        return classLoader.getResource(resource) != null;
     }
 
     static void closeQuietly(AutoCloseable c) {


### PR DESCRIPTION
Many environments start threads without setting a context classloader, in which case `getContextClassLoader` returns `null` and the current code throws a NPE. To avoid NPE in such environments, we need to fallback to other means of finding a classloader.