### PR TITLE
Lazily evaluate available engines.

### DIFF
--- a/graphviz-java/src/main/java/guru/nidi/graphviz/engine/Graphviz.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/engine/Graphviz.java
@@ -40,8 +40,9 @@ public final class Graphviz {
     private static final Logger LOG = LoggerFactory.getLogger(Graphviz.class);
 
     private static final Pattern DPI_PATTERN = Pattern.compile("\"?dpi\"?\\s*=\\s*\"?([0-9.]+)\"?", CASE_INSENSITIVE);
+
     @Nullable
-    private static List<GraphvizEngine> AVAILABLE_ENGINES = null;
+    private static volatile List<GraphvizEngine> availableEngines;
 
     @Nullable
     private static volatile BlockingQueue<GraphvizEngine> engineQueue;
@@ -77,9 +78,11 @@ public final class Graphviz {
     }
 
     private static List<GraphvizEngine> availableEngines() {
-        if (AVAILABLE_ENGINES != null) {
-            return AVAILABLE_ENGINES;
+        final List<GraphvizEngine> availableEngines = Graphviz.availableEngines;
+        if (availableEngines != null) {
+            return availableEngines;
         }
+
         final List<GraphvizEngine> engines = new ArrayList<>();
         if (GraphvizCmdLineEngine.AVAILABLE) {
             engines.add(new GraphvizCmdLineEngine());
@@ -95,7 +98,9 @@ public final class Graphviz {
                     + " Either add the needed dependencies on the classpath"
                     + " or explicitly use 'Graphviz.useEngine(new GraphvizServerEngine())'.");
         }
-        return AVAILABLE_ENGINES = engines;
+        Graphviz.availableEngines = engines;
+
+        return engines;
     }
 
     public static void useDefaultEngines() {

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/engine/Graphviz.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/engine/Graphviz.java
@@ -40,7 +40,8 @@ public final class Graphviz {
     private static final Logger LOG = LoggerFactory.getLogger(Graphviz.class);
 
     private static final Pattern DPI_PATTERN = Pattern.compile("\"?dpi\"?\\s*=\\s*\"?([0-9.]+)\"?", CASE_INSENSITIVE);
-    private static final List<GraphvizEngine> AVAILABLE_ENGINES = availableEngines();
+    @Nullable
+    private static List<GraphvizEngine> AVAILABLE_ENGINES = null;
 
     @Nullable
     private static volatile BlockingQueue<GraphvizEngine> engineQueue;
@@ -76,6 +77,9 @@ public final class Graphviz {
     }
 
     private static List<GraphvizEngine> availableEngines() {
+        if (AVAILABLE_ENGINES != null) {
+            return AVAILABLE_ENGINES;
+        }
         final List<GraphvizEngine> engines = new ArrayList<>();
         if (GraphvizCmdLineEngine.AVAILABLE) {
             engines.add(new GraphvizCmdLineEngine());
@@ -91,11 +95,11 @@ public final class Graphviz {
                     + " Either add the needed dependencies on the classpath"
                     + " or explicitly use 'Graphviz.useEngine(new GraphvizServerEngine())'.");
         }
-        return engines;
+        return AVAILABLE_ENGINES = engines;
     }
 
     public static void useDefaultEngines() {
-        useEngine(AVAILABLE_ENGINES);
+        useEngine(availableEngines());
     }
 
     public static void useEngine(GraphvizEngine first, GraphvizEngine... rest) {


### PR DESCRIPTION
Currently, `availableEngines()` is always evaluated when `GraphViz` is class-loaded. This is wasteful if the user manually set an engine with `useEngine()`, and can be problematic if the JDK has been trimmed using `jlink` for whatever reason. In my normal docker base image, which is heavily trimmed, I get this message even though I have graphviz installed and don't really need the font functionality.

```
Caused by: java.lang.NullPointerException
	at sun.awt.FontConfiguration.getVersion(Unknown Source) ~[?:?]
	at sun.awt.FontConfiguration.readFontConfigFile(Unknown Source) ~[?:?]
	at sun.awt.FontConfiguration.init(Unknown Source) ~[?:?]
	at sun.awt.X11FontManager.createFontConfiguration(Unknown Source) ~[?:?]
	at sun.font.SunFontManager$2.run(Unknown Source) ~[?:?]
	at java.security.AccessController.doPrivileged(Unknown Source) ~[?:?]
	at sun.font.SunFontManager.<init>(Unknown Source) ~[?:?]
	at sun.awt.FcFontManager.<init>(Unknown Source) ~[?:?]
	at sun.awt.X11FontManager.<init>(Unknown Source) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source) ~[?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Unknown Source) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Unknown Source) ~[?:?]
	at sun.font.FontManagerFactory$1.run(Unknown Source) ~[?:?]
	at java.security.AccessController.doPrivileged(Unknown Source) ~[?:?]
	at sun.font.FontManagerFactory.getInstance(Unknown Source) ~[?:?]
	at java.awt.Font.getFont2D(Unknown Source) ~[?:?]
	at java.awt.Font$FontAccessImpl.getFont2D(Unknown Source) ~[?:?]
	at sun.font.FontUtilities.getFont2D(Unknown Source) ~[?:?]
	at sun.font.StandardGlyphVector.initFontData(Unknown Source) ~[?:?]
	at sun.font.StandardGlyphVector.init(Unknown Source) ~[?:?]
	at sun.font.StandardGlyphVector.<init>(Unknown Source) ~[?:?]
	at java.awt.Font.createGlyphVector(Unknown Source) ~[?:?]
	at guru.nidi.graphviz.engine.FontMeasurer.charWidth(FontMeasurer.java:43) ~[graphviz-java-0.16.0.jar:?]
```