### PR TITLE
Updating batik-rasterizer to fix a vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ To rasterize with batik, provide this library on the classpath:
 <dependency>
     <groupId>org.apache.xmlgraphics</groupId>
     <artifactId>batik-rasterizer</artifactId>
-    <version>1.10</version>
+    <version>1.13</version>
 </dependency>
 ```
 

--- a/graphviz-java/pom.xml
+++ b/graphviz-java/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.apache.xmlgraphics</groupId>
             <artifactId>batik-rasterizer</artifactId>
-            <version>1.10</version>
+            <version>1.13</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Updating batik-rasterizer to fix vulnerability
 in its dependency, `batik-svgrasterizer`.

Vulnerability finding:
https://snyk.io/vuln/maven:org.apache.xmlgraphics%3Abatik-svgrasterizer