### PR TITLE
Make code-assert a test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>guru.nidi</groupId>
             <artifactId>code-assert</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
`code-assert` is using `checkstyle:6.19` that pulls in `commons-beanutils:1.9.2`, which is subject to [CVE-2019-10086](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10086) (see also [here](https://snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111)).

While [this](https://github.com/nidi3/code-assert/pull/39) addresses the issue in `code-assert`, I believe this dependency should not be scoped to `compile` in `graphviz-java` to begin with, unless I am missing something.