### PR TITLE
Add API Javadoc

### DIFF
--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Attributes.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Attributes.java
@@ -22,6 +22,11 @@ import java.util.Map.Entry;
 
 import static java.util.Arrays.asList;
 
+/**
+ * Customization options for Graphviz nodes, edges, graphs, etc.
+ * 
+ * @see <a href="https://graphviz.org/doc/info/attrs.html">Attributes</a>
+ */
 public interface Attributes<F extends For> extends Iterable<Entry<String, Object>> {
     static <F extends For> Attributes<F> attr(String key, @Nullable Object value) {
         return new MapAttributes<F>(key, value);

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Color.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Color.java
@@ -23,7 +23,7 @@ import static java.util.stream.Collectors.joining;
 /**
  * Color attribute.
  * 
- * @see https://www.graphviz.org/docs/attrs/color/
+ * @see <a href="https://www.graphviz.org/docs/attrs/color/">color</a>
  */
 public class Color extends SingleAttributes<String, ForAll> {
     private Color(String key, String value) {
@@ -39,7 +39,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * 
      * @return this color as fill color attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/fillcolor/
+     * @see <a href="https://www.graphviz.org/docs/attrs/fillcolor/">fillcolor</a>
      */
     public Color fill() {
         return key("fillcolor");
@@ -50,7 +50,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * 
      * @return this color as background color attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/bgcolor/
+     * @see <a href="https://www.graphviz.org/docs/attrs/bgcolor/">bgcolor</a>
      */
     public Color background() {
         return key("bgcolor");
@@ -61,7 +61,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * 
      * @return this color as font color attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/fontcolor/
+     * @see <a href="https://www.graphviz.org/docs/attrs/fontcolor/">fontcolor</a>
      */
     public Color font() {
         return key("fontcolor");
@@ -72,7 +72,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * 
      * @return this color as label font color attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/labelfontcolor/
+     * @see <a href="https://www.graphviz.org/docs/attrs/labelfontcolor/">labelfontcolor</a>
      */
     public Color labelFont() {
         return key("labelfontcolor");
@@ -111,7 +111,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * @param c a color
      * @return a {@code colorList} of this color and argument
      * 
-     * @see https://www.graphviz.org/docs/attr-types/colorList/
+     * @see <a href="https://www.graphviz.org/docs/attr-types/colorList/">colorList</a>
      */
     public Color and(Color c) {
         return new Color(value + ":" + c.value);
@@ -123,7 +123,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * @param cs colors
      * @return a {@code colorList} of this color and arguments
      * 
-     * @see https://www.graphviz.org/docs/attr-types/colorList/
+     * @see <a href="https://www.graphviz.org/docs/attr-types/colorList/">colorList</a>
      */
     public Color and(Color... cs) {
         return new Color(value + ":" + Stream.of(cs).map(c -> c.value).collect(joining(":")));
@@ -138,7 +138,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * @return a {@code colorList} of this color and argument, with the
      *         specified gradient angle
      * 
-     * @see https://www.graphviz.org/docs/attr-types/colorList/
+     * @see <a href="https://www.graphviz.org/docs/attr-types/colorList/">colorList</a>
      */
     public Color and(Color c, double at) {
         return new Color(value + ":" + c.value + ";" + at);
@@ -150,7 +150,7 @@ public class Color extends SingleAttributes<String, ForAll> {
      * @param angle the angle of the fill
      * @return this color with the specified angle of gradient fill
      * 
-     * @see https://www.graphviz.org/docs/attrs/gradientangle/
+     * @see <a href="https://www.graphviz.org/docs/attrs/gradientangle/">gradientangle</a>
      */
     public Attributes<ForAll> angle(int angle) {
         return attrs(this, new SingleAttributes<>("gradientangle", angle));

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Color.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Color.java
@@ -20,6 +20,11 @@ import java.util.stream.Stream;
 import static guru.nidi.graphviz.attribute.Attributes.attrs;
 import static java.util.stream.Collectors.joining;
 
+/**
+ * Color attribute.
+ * 
+ * @see https://www.graphviz.org/docs/attrs/color/
+ */
 public class Color extends SingleAttributes<String, ForAll> {
     private Color(String key, String value) {
         super(key, value);
@@ -29,65 +34,177 @@ public class Color extends SingleAttributes<String, ForAll> {
         super("color", value);
     }
 
+    /**
+     * Returns this color as fill color attribute
+     * 
+     * @return this color as fill color attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/fillcolor/
+     */
     public Color fill() {
         return key("fillcolor");
     }
 
+    /**
+     * Returns this color as background color attribute
+     * 
+     * @return this color as background color attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/bgcolor/
+     */
     public Color background() {
         return key("bgcolor");
     }
 
+    /**
+     * Returns this color as font color attribute
+     * 
+     * @return this color as font color attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/fontcolor/
+     */
     public Color font() {
         return key("fontcolor");
     }
 
+    /**
+     * Returns this color as label font color attribute
+     * 
+     * @return this color as label font color attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/labelfontcolor/
+     */
     public Color labelFont() {
         return key("labelfontcolor");
     }
 
+    /**
+     * Creates a gradient of this color and another color. This method is
+     * an alias of {@link #and(Color)}.
+     * 
+     * @param c a color
+     * @return a gradient of this color and argument
+     * 
+     * @see #and(Color)
+     */
     public Color gradient(Color c) {
         return and(c);
     }
 
+    /**
+     * Creates a gradient of this color and another color with the specified
+     * gradient angle. This method is an alias of {@link #and(Color,double)}.
+     * 
+     * @param c  a color
+     * @param at the gradient angle
+     * @return a gradient of this color and argument
+     * 
+     * @see #and(Color,double)
+     */
     public Color gradient(Color c, double at) {
         return and(c, at);
     }
 
+    /**
+     * Creates a {@code colorList} of this color and another color.
+     * 
+     * @param c a color
+     * @return a {@code colorList} of this color and argument
+     * 
+     * @see https://www.graphviz.org/docs/attr-types/colorList/
+     */
     public Color and(Color c) {
         return new Color(value + ":" + c.value);
     }
 
+    /**
+     * Creates a {@code colorList} of this color and other colors.
+     * 
+     * @param cs colors
+     * @return a {@code colorList} of this color and arguments
+     * 
+     * @see https://www.graphviz.org/docs/attr-types/colorList/
+     */
     public Color and(Color... cs) {
         return new Color(value + ":" + Stream.of(cs).map(c -> c.value).collect(joining(":")));
     }
 
+    /**
+     * Creates a {@code colorList} of this color and another color with the
+     * specified gradient angle.
+     * 
+     * @param c  a color
+     * @param at the gradient angle
+     * @return a {@code colorList} of this color and argument, with the
+     *         specified gradient angle
+     * 
+     * @see https://www.graphviz.org/docs/attr-types/colorList/
+     */
     public Color and(Color c, double at) {
         return new Color(value + ":" + c.value + ";" + at);
     }
 
+    /**
+     * Specifies the angle of the gradient fill.
+     * 
+     * @param angle the angle of the fill
+     * @return this color with the specified angle of gradient fill
+     * 
+     * @see https://www.graphviz.org/docs/attrs/gradientangle/
+     */
     public Attributes<ForAll> angle(int angle) {
         return attrs(this, new SingleAttributes<>("gradientangle", angle));
     }
 
+    /**
+     * Creates a radial fill attribute with a gradient angle of 0.
+     * 
+     * @return a radial fill attribute
+     */
     public Attributes<ForGraphNode> radial() {
         return radial(0);
     }
 
+    /**
+     * Creates a radial fill attribute with the specified gradient angle.
+     * 
+     * @param angle the gradient angle
+     * @return a radial fill attribute
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Attributes<ForGraphNode> radial(int angle) {
         return attrs((Attributes) this, new SingleAttributes<>("gradientangle", angle), Style.RADIAL);
     }
 
+    /**
+     * Creates a striped fill attribute.
+     * 
+     * @return a striped fill attribute
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Attributes<ForGraphNode> striped() {
         return attrs((Attributes) this, Style.STRIPED);
     }
 
+    /**
+     * Creates a wedged fill attribute.
+     * 
+     * @return a wedged fill attribute
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Attributes<ForGraphNode> wedged() {
         return attrs((Attributes) this, Style.WEDGED);
     }
 
+    /**
+     * Creates a new color with the specified RGB value.
+     * 
+     * @param rgb the RGB value represented as a hexadecimal string
+     * @return a color with the specified RGB value
+     * 
+     * @throws IllegalArgumentException if argument is not a 6-digit
+     *                                  hexadecimal number
+     */
     public static Color rgb(String rgb) {
         final String val = rgb.startsWith("#") ? rgb.substring(1) : rgb;
         if (val.length() != 6) {
@@ -96,14 +213,37 @@ public class Color extends SingleAttributes<String, ForAll> {
         return new Color("#" + val);
     }
 
+    /**
+     * Creates a new color with the specified RGB value.
+     * 
+     * @param rgb the RGB value
+     * @return a color with the specified RGB value
+     */
     public static Color rgb(int rgb) {
         return rgb(hex(rgb >> 16) + hex(rgb >> 8) + hex(rgb));
     }
 
+    /**
+     * Creates a new color with the specified RGB value.
+     * 
+     * @param r the R value
+     * @param g the G value
+     * @param b the B value
+     * @return a color with the specified RGB value
+     */
     public static Color rgb(int r, int g, int b) {
         return rgb(hex(r) + hex(g) + hex(b));
     }
 
+    /**
+     * Creates a new color with the specified RGBA value.
+     * 
+     * @param rgba the RGBA value represented as a hexadecimal string
+     * @return a color with the specified RGBA value
+     * 
+     * @throws IllegalArgumentException if argument is not a 8-digit
+     *                                  hexadecimal number
+     */
     public static Color rgba(String rgba) {
         final String val = rgba.startsWith("#") ? rgba.substring(1) : rgba;
         if (val.length() != 8) {
@@ -112,10 +252,25 @@ public class Color extends SingleAttributes<String, ForAll> {
         return new Color("#" + val);
     }
 
+    /**
+     * Creates a new color with the specified RGBA value.
+     * 
+     * @param rgb a RGBA value
+     * @return a color with the specified RGBA value
+     */
     public static Color rgba(int rgba) {
         return rgba(hex(rgba >> 16) + hex(rgba >> 8) + hex(rgba) + hex(rgba >> 24));
     }
 
+    /**
+     * Creates a new color with the specified RGBA value.
+     * 
+     * @param r the R value
+     * @param g the G value
+     * @param b the B value
+     * @param a the A value
+     * @return a color with the specified RGBA value
+     */
     public static Color rgba(int r, int g, int b, int a) {
         return rgb(hex(r) + hex(g) + hex(b) + hex(a));
     }
@@ -125,6 +280,16 @@ public class Color extends SingleAttributes<String, ForAll> {
         return s.length() == 1 ? "0" + s : s;
     }
 
+    /**
+     * Creates a new color with the specified HSV value.
+     * 
+     * @param h the H value
+     * @param s the S value
+     * @param v the V value
+     * @return a color with the specified HSV value
+     * 
+     * @throws IllegalArgumentException if any of the arguments is {@code <0} or {@code >1}
+     */
     public static Color hsv(double h, double s, double v) {
         if (h < 0 || h > 1 || s < 0 || s > 1 || v < 0 || v > 1) {
             throw new IllegalArgumentException("Values must be 0<=value<=1");
@@ -132,6 +297,12 @@ public class Color extends SingleAttributes<String, ForAll> {
         return new Color(h + " " + s + " " + v);
     }
 
+    /**
+     * Creates a new color with the specified name.
+     * 
+     * @param name the name of the color
+     * @return a named color
+     */
     public static Color named(String name) {
         return new Color(name);
     }

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Color.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Color.java
@@ -255,7 +255,7 @@ public class Color extends SingleAttributes<String, ForAll> {
     /**
      * Creates a new color with the specified RGBA value.
      * 
-     * @param rgb a RGBA value
+     * @param rgba a RGBA value
      * @return a color with the specified RGBA value
      */
     public static Color rgba(int rgba) {

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/EndLabel.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/EndLabel.java
@@ -18,6 +18,9 @@ package guru.nidi.graphviz.attribute;
 import javax.annotation.Nullable;
 import java.util.Objects;
 
+/**
+ * Label placed near the end of an edge.
+ */
 public final class EndLabel extends SimpleLabel implements Attributes<ForLink> {
     private final String key;
     @Nullable
@@ -32,10 +35,34 @@ public final class EndLabel extends SimpleLabel implements Attributes<ForLink> {
         this.distance = distance;
     }
 
+    /**
+     * Creates a label to be placed near the head of an edge.
+     * 
+     * @param label a label
+     * @param angle angle of rotation
+     * @param distance scaling factor for the distance from the head
+     * @return a new head label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/headlabel/">headlabel</a>
+     * @see <a href="https://graphviz.org/docs/attrs/labelangle/">labelangle</a>
+     * @see <a href="https://graphviz.org/docs/attrs/labeldistance/">labeldistance</a>
+     */
     public static EndLabel head(SimpleLabel label, @Nullable Double angle, @Nullable Double distance) {
         return new EndLabel("headlabel", label.value, label.html, angle, distance);
     }
 
+    /**
+     * Creates a label to be placed near the tail of an edge.
+     * 
+     * @param label a label
+     * @param angle angle of rotation
+     * @param distance scaling factor for the distance from the tail
+     * @return a new head label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/taillabel/">taillabel</a>
+     * @see <a href="https://graphviz.org/docs/attrs/labelangle/">labelangle</a>
+     * @see <a href="https://graphviz.org/docs/attrs/labeldistance/">labeldistance</a>
+     */
     public static EndLabel tail(SimpleLabel label, @Nullable Double angle, @Nullable Double distance) {
         return new EndLabel("taillabel", label.value, label.html, angle, distance);
     }
@@ -52,6 +79,12 @@ public final class EndLabel extends SimpleLabel implements Attributes<ForLink> {
         return attributes;
     }
 
+    /**
+     * Determines whether an object is "equal" to this end label.
+     * 
+     * @param o the reference object with which to compare.
+     * @return {@code true} if this end label is the same as the {@code o} argument; {@code false} otherwise.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -69,6 +102,7 @@ public final class EndLabel extends SimpleLabel implements Attributes<ForLink> {
                 && Objects.equals(distance, endLabel.distance);
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), key, angle, distance);

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/GraphAttr.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/GraphAttr.java
@@ -17,59 +17,175 @@ package guru.nidi.graphviz.attribute;
 
 import static java.util.Locale.ENGLISH;
 
+/**
+ * Graph attributes.
+ */
 public final class GraphAttr {
     private static final String SIZE = "size";
 
-    public static final Attributes<ForGraph>
-            CENTER = new SingleAttributes<>("center", true),
-            COMPOUND = new SingleAttributes<>("compound", true),
-            CONCENTRATE = new SingleAttributes<>("concentrate", true),
-            FORCE_LABELS_NOT = new SingleAttributes<>("forcelabels", false),
-            LANDSCAPE = new SingleAttributes<>("orientation", "L");
+    /**
+     * Center the drawing.
+     * 
+     * @see https://www.graphviz.org/docs/attrs/center/
+     */
+    public static final Attributes<ForGraph> CENTER = new SingleAttributes<>("center", true);
+    /**
+     * Allow edges between clusters.
+     * 
+     * @see https://www.graphviz.org/docs/attrs/compound/
+     */
+    public static final Attributes<ForGraph> COMPOUND = new SingleAttributes<>("compound", true);
+    /**
+     * Use edge concentrators.
+     * 
+     * @see https://www.graphviz.org/docs/attrs/concentrate/
+     */
+    public static final Attributes<ForGraph> CONCENTRATE = new SingleAttributes<>("concentrate", true);
+    /**
+     * Do not force placements of all xlabels.
+     * 
+     * @see https://www.graphviz.org/docs/attrs/forcelabels/
+     */
+    public static final Attributes<ForGraph> FORCE_LABELS_NOT = new SingleAttributes<>("forcelabels", false);
+    /**
+     * Set graph orientation to landscape.
+     * 
+     * @see https://www.graphviz.org/docs/attrs/orientation/
+     */
+    public static final Attributes<ForGraph> LANDSCAPE = new SingleAttributes<>("orientation", "L");
 
     private GraphAttr() {
     }
 
+    /**
+     * Specifies the DPI for a graph.
+     * 
+     * @param dpi a DPI value
+     * @return a DPI attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/dpi/
+     */
     public static Attributes<ForGraph> dpi(int dpi) {
         return new SingleAttributes<>("dpi", dpi);
     }
 
+    /**
+     * Specifies the maximum size of the drawn graph.
+     * 
+     * @param size maximum size of the graph
+     * @return a size attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/size/
+     */
     public static Attributes<ForGraph> sizeMax(double size) {
         return new SingleAttributes<>(SIZE, size);
     }
 
+    /**
+     * Specifies the maximum size of the drawn graph.
+     * 
+     * @param sizeX maximum width of the graph
+     * @param sizeY maximum height of the graph
+     * @return a size attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/size/
+     */
     public static Attributes<ForGraph> sizeMax(double sizeX, double sizeY) {
         return new SingleAttributes<>(SIZE, sizeX + "," + sizeY);
     }
 
+    /**
+     * Specifies the preferred size of the drawn graph.
+     * 
+     * @param size preferred size of the graph
+     * @return a size attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/size/
+     */
     public static Attributes<ForGraph> sizePreferred(double size) {
         return new SingleAttributes<>(SIZE, size + "!");
     }
 
+    /**
+     * Specifies the preferred size of the drawn graph.
+     * 
+     * @param sizeX preferred width of the graph
+     * @param sizeY preferred height of the graph
+     * @return a size attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/size/
+     */
     public static Attributes<ForGraph> sizePreferred(double sizeX, double sizeY) {
         return new SingleAttributes<>(SIZE, sizeX + "," + sizeY + "!");
     }
 
+    /**
+     * Possible options for splines.
+     * 
+     * @see GraphAttr#splines(SplineMode)
+     */
     public enum SplineMode {
         LINE, SPLINE, POLYLINE, ORTHO, CURVED, NONE
     }
 
+    /**
+     * Controls if/how edges are represented.
+     * 
+     * @param mode spline mode
+     * @return a splines attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/splines/
+     */
     public static Attributes<ForGraph> splines(SplineMode mode) {
         return new SingleAttributes<>("splines", mode.toString().toLowerCase(ENGLISH));
     }
 
+    /**
+     * Specifies the padding around a graph.
+     * 
+     * @param pad amount of padding
+     * @return a padding attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/pad/
+     */
     public static Attributes<ForGraph> pad(double pad) {
         return new SingleAttributes<>("pad", pad);
     }
 
+    /**
+     * Specifies the padding around a graph.
+     * 
+     * @param padX amount of horizontal padding
+     * @param padY amount of vertical padding
+     * @return a padding attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/pad/
+     */
     public static Attributes<ForGraph> pad(double padX, double padY) {
         return new SingleAttributes<>("pad", padX + "," + padY);
     }
 
+    /**
+     * Sets the margin around a graph.
+     * 
+     * @param margin the margin to use, in inches
+     * @return a margin attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/margin/
+     */
     public static Attributes<ForGraph> margin(double margin) {
         return new SingleAttributes<>("margin", margin);
     }
 
+    /**
+     * Sets the margin around a graph.
+     * 
+     * @param marginX the horizontal margin to use, in inches
+     * @param marginY the vertical margin to use, in inches
+     * @return a margin attribute
+     * 
+     * @see https://www.graphviz.org/docs/attrs/margin/
+     */
     public static Attributes<ForGraph> margin(double marginX, double marginY) {
         return new SingleAttributes<>("margin", marginX + "," + marginY);
     }

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/GraphAttr.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/GraphAttr.java
@@ -88,7 +88,7 @@ public final class GraphAttr {
      * @param sizeY maximum height of the graph
      * @return a size attribute
      * 
-     * @see <a href="<a href="https://www.graphviz.org/docs/attrs/size/">size</a>">size</a>
+     * @see <a href="https://www.graphviz.org/docs/attrs/size/">size</a>">
      */
     public static Attributes<ForGraph> sizeMax(double sizeX, double sizeY) {
         return new SingleAttributes<>(SIZE, sizeX + "," + sizeY);

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/GraphAttr.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/GraphAttr.java
@@ -26,31 +26,31 @@ public final class GraphAttr {
     /**
      * Center the drawing.
      * 
-     * @see https://www.graphviz.org/docs/attrs/center/
+     * @see <a href="https://www.graphviz.org/docs/attrs/center/">center</a>
      */
     public static final Attributes<ForGraph> CENTER = new SingleAttributes<>("center", true);
     /**
      * Allow edges between clusters.
      * 
-     * @see https://www.graphviz.org/docs/attrs/compound/
+     * @see <a href="https://www.graphviz.org/docs/attrs/compound/">compound</a>
      */
     public static final Attributes<ForGraph> COMPOUND = new SingleAttributes<>("compound", true);
     /**
      * Use edge concentrators.
      * 
-     * @see https://www.graphviz.org/docs/attrs/concentrate/
+     * @see <a href="https://www.graphviz.org/docs/attrs/concentrate/">concentrate</a>
      */
     public static final Attributes<ForGraph> CONCENTRATE = new SingleAttributes<>("concentrate", true);
     /**
      * Do not force placements of all xlabels.
      * 
-     * @see https://www.graphviz.org/docs/attrs/forcelabels/
+     * @see <a href="https://www.graphviz.org/docs/attrs/forcelabels/">forcelabels</a>
      */
     public static final Attributes<ForGraph> FORCE_LABELS_NOT = new SingleAttributes<>("forcelabels", false);
     /**
      * Set graph orientation to landscape.
      * 
-     * @see https://www.graphviz.org/docs/attrs/orientation/
+     * @see <a href="https://www.graphviz.org/docs/attrs/orientation/">orientation</a>
      */
     public static final Attributes<ForGraph> LANDSCAPE = new SingleAttributes<>("orientation", "L");
 
@@ -63,7 +63,7 @@ public final class GraphAttr {
      * @param dpi a DPI value
      * @return a DPI attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/dpi/
+     * @see <a href="https://www.graphviz.org/docs/attrs/dpi/">dpi</a>
      */
     public static Attributes<ForGraph> dpi(int dpi) {
         return new SingleAttributes<>("dpi", dpi);
@@ -75,7 +75,7 @@ public final class GraphAttr {
      * @param size maximum size of the graph
      * @return a size attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/size/
+     * @see <a href="https://www.graphviz.org/docs/attrs/size/">size</a>
      */
     public static Attributes<ForGraph> sizeMax(double size) {
         return new SingleAttributes<>(SIZE, size);
@@ -88,7 +88,7 @@ public final class GraphAttr {
      * @param sizeY maximum height of the graph
      * @return a size attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/size/
+     * @see <a href="<a href="https://www.graphviz.org/docs/attrs/size/">size</a>">size</a>
      */
     public static Attributes<ForGraph> sizeMax(double sizeX, double sizeY) {
         return new SingleAttributes<>(SIZE, sizeX + "," + sizeY);
@@ -100,7 +100,7 @@ public final class GraphAttr {
      * @param size preferred size of the graph
      * @return a size attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/size/
+     * @see <a href="https://www.graphviz.org/docs/attrs/size/">size</a>
      */
     public static Attributes<ForGraph> sizePreferred(double size) {
         return new SingleAttributes<>(SIZE, size + "!");
@@ -113,7 +113,7 @@ public final class GraphAttr {
      * @param sizeY preferred height of the graph
      * @return a size attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/size/
+     * @see <a href="https://www.graphviz.org/docs/attrs/size/">size</a>
      */
     public static Attributes<ForGraph> sizePreferred(double sizeX, double sizeY) {
         return new SingleAttributes<>(SIZE, sizeX + "," + sizeY + "!");
@@ -134,7 +134,7 @@ public final class GraphAttr {
      * @param mode spline mode
      * @return a splines attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/splines/
+     * @see <a href="https://www.graphviz.org/docs/attrs/splines/">dpi</a>
      */
     public static Attributes<ForGraph> splines(SplineMode mode) {
         return new SingleAttributes<>("splines", mode.toString().toLowerCase(ENGLISH));
@@ -146,7 +146,7 @@ public final class GraphAttr {
      * @param pad amount of padding
      * @return a padding attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/pad/
+     * @see <a href="https://www.graphviz.org/docs/attrs/pad/">dpi</a>
      */
     public static Attributes<ForGraph> pad(double pad) {
         return new SingleAttributes<>("pad", pad);
@@ -159,7 +159,7 @@ public final class GraphAttr {
      * @param padY amount of vertical padding
      * @return a padding attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/pad/
+     * @see <a href="https://www.graphviz.org/docs/attrs/pad/">dpi</a>
      */
     public static Attributes<ForGraph> pad(double padX, double padY) {
         return new SingleAttributes<>("pad", padX + "," + padY);
@@ -171,7 +171,7 @@ public final class GraphAttr {
      * @param margin the margin to use, in inches
      * @return a margin attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/margin/
+     * @see <a href="https://www.graphviz.org/docs/attrs/margin/">dpi</a>
      */
     public static Attributes<ForGraph> margin(double margin) {
         return new SingleAttributes<>("margin", margin);
@@ -184,7 +184,7 @@ public final class GraphAttr {
      * @param marginY the vertical margin to use, in inches
      * @return a margin attribute
      * 
-     * @see https://www.graphviz.org/docs/attrs/margin/
+     * @see <a href="https://www.graphviz.org/docs/attrs/margin/">dpi</a>
      */
     public static Attributes<ForGraph> margin(double marginX, double marginY) {
         return new SingleAttributes<>("margin", marginX + "," + marginY);

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Image.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Image.java
@@ -15,7 +15,17 @@
  */
 package guru.nidi.graphviz.attribute;
 
+/**
+ * Image attribute.
+ * 
+ * @see <a href="https://graphviz.org/docs/attrs/image/">image</a>
+ */
 public final class Image implements Attributes<ForNode> {
+    /**
+     * Image positioning options.
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/imagepos/">imagepos</a>
+     */
     public enum Position {
         TOP_LEFT("tl"),
         TOP_CENTER("tc"),
@@ -34,6 +44,11 @@ public final class Image implements Attributes<ForNode> {
         }
     }
 
+    /**
+     * Image scaling options.
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/imagescale/">imagescale</a>
+     */
     public enum Scale {
         NONE("false"),
         FIT("true"),
@@ -58,14 +73,36 @@ public final class Image implements Attributes<ForNode> {
         this.scale = scale;
     }
 
+    /**
+     * Creates a new image attribute.
+     * 
+     * @param path path to image resource
+     * @return a new image attribute with the specified resource
+     */
     public static Image of(String path) {
         return new Image(path, Position.MIDDLE_CENTER, Scale.NONE);
     }
 
+    /**
+     * Modifies how this image is positioned in the containing node.
+     * 
+     * @param position position of the image
+     * @return a new image attribute with the specified position
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/imagepos/">imagepos</a>
+     */
     public Image position(Position position) {
         return new Image(path, position, scale);
     }
 
+    /**
+     * Modifies how this image fills the containing node.
+     * 
+     * @param scale scaling option
+     * @return a new image attribute with the specified scaling
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/imagescale/">imagescale</a>
+     */
     public Image scale(Scale scale) {
         return new Image(path, position, scale);
     }

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Label.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Label.java
@@ -35,10 +35,20 @@ public final class Label extends SimpleLabel implements Attributes<ForAll> {
     public static final String HEAD_NAME = "\\H";
     public static final String TAIL_NAME = "\\T";
 
+    /**
+     * Justification options for a label.
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/labeljust/">labeljust</a>
+     */
     public enum Justification {
         LEFT, MIDDLE, RIGHT
     }
 
+    /**
+     * Location options for a label.
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/labelloc/">labelloc</a>
+     */
     public enum Location {
         TOP, CENTER, BOTTOM
     }
@@ -208,42 +218,116 @@ public final class Label extends SimpleLabel implements Attributes<ForAll> {
         return hasTags ? html(untagged) : markdown(untagged);
     }
 
+    /**
+     * Returns this label as a head label.
+     * 
+     * @return a head label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/headlabel/">headlabel</a>
+     */
     public EndLabel head() {
         return EndLabel.head(this, null, null);
     }
 
+    /**
+     * Returns this label as a head label, with the specified positioning attributes.
+     * 
+     * @param angle angle of rotation
+     * @param distance scaling factor for the distance from the head
+     * @return a head label
+     * 
+     * @see EndLabel#head(SimpleLabel, Double, Double)
+     */
     public EndLabel head(double angle, double distance) {
         return EndLabel.head(this, angle, distance);
     }
 
+    /**
+     * Returns this label as a tail label.
+     * 
+     * @return a tail label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/taillabel/">taillabel</a>
+     */
     public EndLabel tail() {
         return EndLabel.tail(this, null, null);
     }
 
+    /**
+     * Returns this label as a tail label, with the specified positioning attributes.
+     * 
+     * @param angle angle of rotation
+     * @param distance scaling factor for the distance from the tail
+     * @return a tail label
+     * 
+     * @see EndLabel#tail(SimpleLabel, Double, Double)
+     */
     public EndLabel tail(double angle, double distance) {
         return EndLabel.tail(this, angle, distance);
     }
 
+    /**
+     * Returns this label as an external label.
+     * 
+     * @return an external label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/xlabel/">xlabel</a>
+     */
     public Label external() {
         return new Label(value, html, true, floating, decorated, just, loc);
     }
 
+    /**
+     * Returns this label as a floating label.
+     * 
+     * @return a floating label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/labelfloat/">labelfloat</a>
+     */
     public Label floating() {
         return new Label(value, html, external, true, decorated, just, loc);
     }
 
+    /**
+     * Returns this label as a decorating label for an edge.
+     * 
+     * @return a decorating label
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/decorate/">decorate</a>
+     */
     public Label decorated() {
         return new Label(value, html, external, floating, true, just, loc);
     }
 
+    /**
+     * Modifies justification for this label.
+     * 
+     * @param just a justification option
+     * @return a new label with the specified justification
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/labeljust/">labeljust</a>
+     */
     public Label justify(Justification just) {
         return new Label(value, html, external, floating, decorated, just, loc);
     }
 
+    /**
+     * Modifies location of this label, relative to the graph element.
+     * 
+     * @param just a location option
+     * @return a new label with the specified location
+     * 
+     * @see <a href="https://graphviz.org/docs/attrs/labelloc/">labelloc</a>
+     */
     public Label locate(Location loc) {
         return new Label(value, html, external, floating, decorated, just, loc);
     }
 
+    /**
+     * Determines whether this label is an external label.
+     * 
+     * @return {@code true} if this label is an external label
+     */
     public boolean isExternal() {
         return external;
     }
@@ -272,6 +356,7 @@ public final class Label extends SimpleLabel implements Attributes<ForAll> {
         return attributes;
     }
 
+    /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -291,11 +376,13 @@ public final class Label extends SimpleLabel implements Attributes<ForAll> {
                 && loc == label.loc;
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), external, floating, decorated, just, loc);
     }
 
+    /** {@inheritDoc} */
     @Override
     public String toString() {
         return value;

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Label.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/Label.java
@@ -24,6 +24,11 @@ import static guru.nidi.graphviz.attribute.Label.Location.BOTTOM;
 import static guru.nidi.graphviz.attribute.Label.Location.TOP;
 import static java.util.stream.Collectors.joining;
 
+/**
+ * Text label for objects.
+ * 
+ * @see <a href="https://graphviz.org/docs/attrs/label/">label</a>
+ */
 public final class Label extends SimpleLabel implements Attributes<ForAll> {
     public static final String NODE_NAME = "\\N";
     public static final String GRAPH_NAME = "\\G";

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/SimpleLabel.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/attribute/SimpleLabel.java
@@ -34,10 +34,20 @@ public class SimpleLabel {
         return value instanceof SimpleLabel ? (SimpleLabel) value : of(value.toString());
     }
 
+    /**
+     * Returns the value stored in this label after serializing.
+     * 
+     * @return the value stored in this label, after serialization
+     */
     public String serialized() {
         return html ? ("<" + value + ">") : ("\"" + quoted() + "\"");
     }
 
+    /**
+     * Returns the value stored in this label after serializing, but without delimiters.
+     * 
+     * @return the value stored in this label, after serialization
+     */
     public String simpleSerialized() {
         return html ? value : quoted();
     }
@@ -57,18 +67,40 @@ public class SimpleLabel {
         return value;
     }
 
+    /**
+     * Determines whether a string is equal to the value stored in this label
+     * 
+     * @param s a string
+     * @return {@code true} if the value stored in this label is equal to the argument
+     */
     public boolean contentEquals(String s) {
         return value.equals(s);
     }
 
+    /**
+     * Determines whether the content of this label is empty.
+     * 
+     * @return {@code true} if the value stored in this label has length of 0.
+     */
     public boolean isContentEmpty() {
         return value.isEmpty();
     }
 
+    /**
+     * Determines whether this label represents an HTML string.
+     * 
+     * @return {@code true} if this label represents an HTML string
+     */
     public boolean isHtml() {
         return html;
     }
 
+    /**
+     * Determines whether an object is "equal" to this label.
+     * 
+     * @param o the reference object with which to compare.
+     * @return {@code true} if this label is the same as the {@code o} argument; {@code false} otherwise.
+     */
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -82,11 +114,16 @@ public class SimpleLabel {
                 && Objects.equals(value, that.value);
     }
 
+    /** {@inheritDoc} */
     @Override
     public int hashCode() {
         return Objects.hash(value, html);
     }
 
+    /**
+     * Returns the string representation of this label.
+     * @return the string representation of this label
+     */
     @Override
     public String toString() {
         return value;

--- a/graphviz-java/src/main/java/guru/nidi/graphviz/model/Graph.java
+++ b/graphviz-java/src/main/java/guru/nidi/graphviz/model/Graph.java
@@ -19,26 +19,102 @@ import guru.nidi.graphviz.attribute.*;
 
 import java.util.List;
 
+/**
+ * A Graphviz graph.
+ * 
+ * @see <a href="https://graphviz.org/docs/graph/">Graph</a>
+ */
 public interface Graph extends LinkSource, LinkTarget {
+    /**
+     * Makes a copy of this graph as a strict graph.
+     * 
+     * @return a copy of this graph, as a strict graph.
+     * 
+     * @see <a href=
+     *      "https://graphviz.org/doc/info/lang.html#lexical-and-semantic-notes">Lexical
+     *      and Semantic Notes</a>
+     */
     Graph strict();
 
+    /**
+     * Makes a copy of this graph as a directed graph.
+     * 
+     * @return a copy of this graph, as a directed graph.
+     * 
+     * @see <a href=
+     *      "https://graphviz.org/doc/info/lang.html#lexical-and-semantic-notes">Lexical
+     *      and Semantic Notes</a>
+     */
     Graph directed();
 
+    /**
+     * Makes a copy of this graph as a cluster.
+     * 
+     * @return a copy of this graph, as a cluster
+     * 
+     * @see <a href=
+     *      "https://graphviz.org/doc/info/lang.html#subgraphs-and-clusters">Subgraphs
+     *      and Clusters</a>
+     */
     Graph cluster();
 
+    /**
+     * Makes a copy of this graph with the specified name.
+     * 
+     * @param name a name for the copied graph
+     * @return a copy of this graph with the specified name
+     */
     Graph named(String name);
 
+    /**
+     * Creates links to the specified elements
+     * 
+     * @param targets elements to link this graph
+     * @return a graph
+     */
     Graph link(LinkTarget... targets);
 
+    /**
+     * Creates a graph with the specified elements.
+     * 
+     * @param sources elements to add to the graph
+     * @return a graph with the specified elements
+     */
     Graph with(LinkSource... sources);
 
+    /**
+     * Creates a graph with the specified elements.
+     * 
+     * @param sources list of elements to add to the graph
+     * @return a graph with the specified elements
+     */
     Graph with(List<? extends LinkSource> sources);
 
+    /**
+     * Sets global node attributes.
+     * 
+     * @return node attributes
+     */
     Attributed<Graph, ForNode> nodeAttr();
 
+    /**
+     * Sets global link attributes.
+     * 
+     * @return link attributes
+     */
     Attributed<Graph, ForLink> linkAttr();
 
+    /**
+     * Sets global link attributes.
+     * 
+     * @return link attributes
+     */
     Attributed<Graph, ForGraph> graphAttr();
 
+    /**
+     * Returns this graph as a mutable graph.
+     * 
+     * @return a mutable graph
+     */
     MutableGraph toMutable();
 }


### PR DESCRIPTION
This API provides (almost) no documentation, aside from what's available in [README.md](https://github.com/nidi3/graphviz-java/blob/master/README.md). This PR adds this missing documentation as Javadoc.